### PR TITLE
Proper arguments support and support w3m backend

### DIFF
--- a/nekofetch
+++ b/nekofetch
@@ -1,24 +1,37 @@
 #!/bin/sh
 
 tmpfile="$(mktemp)"
+imgurl="https://nekos.life/api/v2/img/neko"
+height="$(($(stty size | awk '{print $1}') - 5))"
 
-case "$1" in
-    "--nsfw"|"nsfw"|"-n"|"n")
-        [ "$DEBUG" = "true" ] && echo "Getting a nsfw image"
-        imgurl="https://nekos.life/api/v2/img/cum_jpg"
-        ;;
-    "--sfw"|"sfw"|"-s"|"s")
-        [ "$DEBUG" = "true" ] && echo "Getting a sfw image"
-        imgurl="https://nekos.life/api/v2/img/neko"
-        ;;
-    *)
-        [ "$DEBUG" = "true" ] && echo "Could not interpret as either sfw or nsfw. Defaulting to sfw."
-        imgurl="https://nekos.life/api/v2/img/neko"
-        ;;
-esac
-
-echo "$2" | grep -qE '^[0-9]+$' && height="$2" || height="$(($(stty size | awk '{print $1}') - 5))"
-[ "$DEBUG" = "true" ] && echo "Using height $height"
+while :; do
+    case "$1" in
+        "--nsfw"|"nsfw"|"-n"|"n")
+            [ "$DEBUG" = "true" ] && echo "Getting a nsfw image"
+            imgurl="https://nekos.life/api/v2/img/cum_jpg"
+            ;;
+        "--sfw"|"sfw"|"-s"|"s")
+            [ "$DEBUG" = "true" ] && echo "Getting a sfw image"
+            imgurl="https://nekos.life/api/v2/img/neko"
+            ;;
+        "--w3m"|"w3m"|"--img"|"img"|"-i"|"i")
+            [ "$DEBUG" = "true" ] && echo "Using w3m image backend for neofetch"
+            use_w3m="true"
+            ;;
+        "--height"|"-h")
+            height="$2"
+            [ "$DEBUG" = "true" ] && echo "Using height $height"
+            shift
+            ;;
+        *)
+            if [ -z "$1" ]; then
+                break
+            fi
+            [ "$DEBUG" = "true" ] && echo "Could not interpret parameter '$1'."
+            ;;
+    esac
+    shift
+done
 
 url=$(curl -fsSL "$imgurl" | jq -r ".url")
 
@@ -31,6 +44,8 @@ if [ "$TERM" = "xterm-kitty" ]; then
     fi
 elif [ "$LC_TERMINAL" = "iTerm2" ]; then
     neofetch --iterm2 "$tmpfile.jpg"
+elif [ "$use_w3m" = "true" ]; then
+    neofetch --w3m "$tmpfile.jpg"
 else
     jp2a --height="$height" "$tmpfile.jpg" > "$tmpfile"
     neofetch --source "$tmpfile"

--- a/nekofetch
+++ b/nekofetch
@@ -1,37 +1,61 @@
 #!/bin/sh
 
 tmpfile="$(mktemp)"
-imgurl="https://nekos.life/api/v2/img/neko"
-height="$(($(stty size | awk '{print $1}') - 5))"
+imgtype=""
+use_height=""
 
 while :; do
     case "$1" in
         "--nsfw"|"nsfw"|"-n"|"n")
-            [ "$DEBUG" = "true" ] && echo "Getting a nsfw image"
-            imgurl="https://nekos.life/api/v2/img/cum_jpg"
+            if [ "$imgtype" = "" ]; then
+                [ "$DEBUG" = "true" ] && echo "Getting a nsfw image"
+                imgtype="nsfw"
+            else
+                echo "$imgtype images were already chosen! Please only specify either sfw or nsfw!"
+            fi
             ;;
         "--sfw"|"sfw"|"-s"|"s")
-            [ "$DEBUG" = "true" ] && echo "Getting a sfw image"
-            imgurl="https://nekos.life/api/v2/img/neko"
+            if [ "$imgtype" = "" ]; then
+                [ "$DEBUG" = "true" ] && echo "Getting a sfw image"
+                imgtype="sfw"
+            else
+                echo "$imgtype images were already chosen! Please only specify either sfw or nsfw!"
+            fi
             ;;
         "--w3m"|"w3m"|"--img"|"img"|"-i"|"i")
             [ "$DEBUG" = "true" ] && echo "Using w3m image backend for neofetch"
             use_w3m="true"
             ;;
         "--height"|"-h")
-            height="$2"
-            [ "$DEBUG" = "true" ] && echo "Using height $height"
+            if [ "$use_height" = "" ]; then
+                use_height="$2"
+                [ "$DEBUG" = "true" ] && echo "Using height $height"
+            else
+                echo "You can only specify the height argument once!"
+            fi
             shift
             ;;
         *)
             if [ -z "$1" ]; then
                 break
             fi
-            [ "$DEBUG" = "true" ] && echo "Could not interpret parameter '$1'."
+            echo "Could not interpret parameter '$1'."
             ;;
     esac
     shift
 done
+
+if [ "$imgtype" = "nsfw" ]; then
+    imgurl="https://nekos.life/api/v2/img/cum_jpg"
+else
+    imgurl="https://nekos.life/api/v2/img/neko"
+fi
+
+if [ "$use_height" != "" ]; then
+    height="$use_height"
+else
+    height="$(($(stty size | awk '{print $1}') - 5))"
+fi
 
 url=$(curl -fsSL "$imgurl" | jq -r ".url")
 


### PR DESCRIPTION
This adds `--w3m` to display images in supporting Linux terminals
It also moves the height argument from $2 to `--height <value>` or `-h <value>` for short.
Now, `--nsfw` and `--sfw` are also supported in any order with the other arguments.

![image](https://user-images.githubusercontent.com/13177694/112770796-a79b5a80-9028-11eb-90f5-3043bef7c846.png)
